### PR TITLE
Add dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,5 @@ setup(name='jinjatree',
       license='MIT',
       packages=['jinjatree'],
       scripts=['bin/jinjatree'],
+      install_requires=['anytree'],
       zip_safe=False)


### PR DESCRIPTION
When running `jinjatree` right after installation you might get the following error:
```
$ jinjatree
Traceback (most recent call last):
  File "/Users/jay/.pyenv/versions/thewiz/bin/jinjatree", line 6, in <module>
    from jinjatree.core import JinjaTree
  File "/Users/jay/.pyenv/versions/3.5.2/envs/thewiz/lib/python3.5/site-packages/jinjatree/core.py", line 4, in <module>
    from anytree import (
ImportError: No module named 'anytree'
```

This PR solves this.